### PR TITLE
Fixed typo with filename. Linux IS case sensitive.

### DIFF
--- a/LinkPreviewOrigin.php
+++ b/LinkPreviewOrigin.php
@@ -24,7 +24,7 @@ class LinkPreviewOrigin{
     }
 
     private static function verifyIfUserAgendIsOnBlockList($userAgentDescription){
-        $blockList = json_decode(file_get_contents(__DIR__.'/blockList.json'), true)['UserAgents'];
+        $blockList = json_decode(file_get_contents(__DIR__.'/BlockList.json'), true)['UserAgents'];
 
         $userAgentDescription = strtolower($userAgentDescription);
         $status = false;


### PR DESCRIPTION
Really naughty and hard to find bug. The filename for BlockList.json was wron. (blockList.json instead of BlockList.json) 
Guess you used Windows, so it worked for you with the capital beginning of the filename.

But that way I could do my first pull - request :-) 
Wish you all the best :-) 

Cheers Julian